### PR TITLE
z_1 만델로브 집합 이미지 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 NAME = fractol
+SRC = main.c\
+	event.c\
+	utils.c\
+	mandelbrot.c
+	
+CFLAG = -Wall -Werror -Wextra
+LINUX = -I /usr/include/lib -lXext -lX11 -lm -lbsd
+MLX = -I mlx -L mlx -l mlx
 
 all :
-
+	gcc -o $(NAME) $(SRC) $(MLX) $(LINUX)
 clean :
 
 fclean :

--- a/fractol.h
+++ b/fractol.h
@@ -30,4 +30,8 @@ int			red_cross(int arg, void *parm);
 **UTILITIE
 */
 void			error(char *str);
+/*
+**MANDELBROT
+*/
+void			mandelbrot(t_mlx mlx);
 #endif

--- a/main.c
+++ b/main.c
@@ -4,6 +4,8 @@ int	main(int arg_n, char **arg_s)
 {
 	t_mlx	mlx;
 
+	mlx.x = 1920;
+	mlx.y = 1080;
 	mlx.ptr = mlx_init();
 	if (!mlx.ptr)
 		error("mlx_init fail");
@@ -11,7 +13,7 @@ int	main(int arg_n, char **arg_s)
 	if (!mlx.win)
 		error("mlx_new_window fail");
 	mlx.img = mlx_new_image(mlx.ptr, mlx.x, mlx.y);
-	if (!mlx.img)
+	if (mlx.img == NULL)
 		error("mlx_new_image fail");
 	mlx.pix_str = mlx_get_data_addr(mlx.img, &mlx.bpp, &mlx.len, &mlx.endian);
 	if (!mlx.pix_str)
@@ -19,7 +21,7 @@ int	main(int arg_n, char **arg_s)
 	mlx_key_hook(mlx.win, escape, 0);
 	mlx_hook(mlx.win, 17, 0, red_cross, 0);
 	//mlx_mouse_hook(mlx.win, zoom, 0);
-	julia
-	mandelbrot
+	//julia
+	mandelbrot(mlx);
 	mlx_loop(mlx.ptr);
 }

--- a/mandelbrot.c
+++ b/mandelbrot.c
@@ -1,0 +1,68 @@
+#include "fractol.h"
+
+float	map(int x, int max, float new_min, float new_max)
+{
+	float place;
+
+	place = (((float)max * new_min) + (((float)new_max - new_min) * x))/ max;
+	return (place);
+}
+
+void	mandelbrot(t_mlx mlx)
+{
+	int	x;
+	int	y;
+	float	ca;
+	float	cb;
+	float	a;
+	float	b;
+	float	aa;
+	float	bb;
+	int	n;
+	int	i;
+	unsigned char r;
+	unsigned char g;
+	unsigned char blue;
+	unsigned char *pixel_byte;
+	float	ratio;
+
+	ratio = (float)mlx.x / mlx.y;
+	n = 0;//변수로 사용 가능
+	x = 0;
+	while (x < mlx.x)
+	{
+		y = 0;
+		while (y < mlx.y)
+		{
+			pixel_byte = mlx.pix_str + mlx.bpp * x / 8 + mlx.len * y;
+			r = 0;
+			g = 0;
+			blue = 0;
+			ca = map(x, mlx.x, -2 * ratio , 2 * ratio);//뒤에 두 값도 변수로 사용 가능
+			cb = map(y, mlx.y, -2, 2);
+			a = ca;
+			b = cb;
+			i = 0;
+			while (i < n)
+			{
+				aa = pow(a, 2) - pow(b, 2) + ca;//승수도 변수로 사용 가능
+				bb = 2 * a * b + cb;
+				a = aa;
+				b = bb;
+				i++;
+			}
+			if (pow(a, 2) + pow(b, 2) <= 4)
+			{
+				r = 255;
+				g = 255;
+				blue = 255;
+			}
+			pixel_byte[0] = r;
+			pixel_byte[1] = g;
+			pixel_byte[2] = blue;
+			y++;
+		}
+		x++;
+	}
+	mlx_put_image_to_window(mlx.ptr, mlx.win, mlx.img, 0, 0);
+}

--- a/utils.c
+++ b/utils.c
@@ -1,4 +1,4 @@
-#include "fratol.h"
+#include "fractol.h"
 
 void	error(char *message)
 {


### PR DESCRIPTION
-mlx를 깃으로 받아서 다시했다. 파일이 제대로 복사되지 않아서 났던 오류가 있었다.
-esc와 redcross가 잘 작동한다.
-원이 찌그러져있었다. x축과 y축 비율이 다른데 복소평면 범위는 1:1비율로 설정했던게 원인이다.
-색은 1byte씩 집어넣었다. 들어가는 위치가 좀 특이하긴하다. int형에 집어넣을 때는 16비트를 옮기고 red를 넣어서, char형 4개에 주소에서는 1인덱스에 red가 들어갈 줄 알았다. 테스트해보니 red는 0인덱스에 들어간다.
-다음은 반복 함수를 한 번 써볼 예정이다.