### PR TITLE
반복 함수 단계 별로 다른 색을 집어넣어 이미지 렌더링

### DIFF
--- a/mandelbrot.c
+++ b/mandelbrot.c
@@ -8,6 +8,13 @@ float	map(int x, int max, float new_min, float new_max)
 	return (place);
 }
 
+void	put_color(unsigned char *pixel, unsigned char r, unsigned char g, unsigned char b)
+{
+	pixel[0] = r;
+	pixel[1] = g;
+	pixel[2] = b;
+}
+
 void	mandelbrot(t_mlx mlx)
 {
 	int	x;
@@ -27,7 +34,7 @@ void	mandelbrot(t_mlx mlx)
 	float	ratio;
 
 	ratio = (float)mlx.x / mlx.y;
-	n = 0;//변수로 사용 가능
+	n = 50;//변수로 사용 가능
 	x = 0;
 	while (x < mlx.x)
 	{
@@ -47,19 +54,19 @@ void	mandelbrot(t_mlx mlx)
 			{
 				aa = pow(a, 2) - pow(b, 2) + ca;//승수도 변수로 사용 가능
 				bb = 2 * a * b + cb;
+				if (pow(aa, 2) + pow(bb, 2) > 4)
+					break;
 				a = aa;
 				b = bb;
 				i++;
 			}
 			if (pow(a, 2) + pow(b, 2) <= 4)
 			{
-				r = 255;
-				g = 255;
-				blue = 255;
+				r = 60 * (i + 1) % 255;
+				g = 50 * (i + 1) % 255;
+				blue = 70 * (i + 1) % 255; 
 			}
-			pixel_byte[0] = r;
-			pixel_byte[1] = g;
-			pixel_byte[2] = blue;
+			put_color(pixel_byte, r, g, blue);
 			y++;
 		}
 		x++;


### PR DESCRIPTION
-모든 픽셀은 한 번만 색을 집어넣는다.
-50번 반복하면서 지름 2의 범위를 넘어 갈 경우 반복문이 깨지고 반복한 횟수에 따른 색이 정해진다.
-60 * i % 255 이런 식으로 값이 255를 넘어가지 않도록 했다.
-r 60 * i g 70 * i b 80 * i로 색이 단조롭지 않도록 만들었다.