### PR TITLE
마우스 휠 구현

### DIFF
--- a/fractol.h
+++ b/fractol.h
@@ -20,6 +20,8 @@ typedef	struct		s_mlx
 	unsigned int	x;
 	unsigned int	y;
 	float		ratio;
+	float		max;
+	float		min;
 }			t_mlx;
 
 typedef struct		s_mandelbrot

--- a/main.c
+++ b/main.c
@@ -1,5 +1,36 @@
 #include "fractol.h"
 
+int	mouse_check(int button, int x, int y, void *parm)
+{
+	t_mlx	*mlx;
+	void	*img;
+
+	mlx = parm;
+	if (button == 4)
+	{
+		printf("close\n");
+		if (mlx->max > mlx->min)
+		{
+			mlx->max *= 0.9;
+			mlx->min *= 0.9;
+		}
+	}
+	else if (button == 5)
+	{
+		printf("far\n");
+		if (mlx->max > mlx->min)
+		{
+			mlx->max *= 1.1;
+			mlx->min *= 1.1;
+		}
+	}
+	img = mlx->img;
+	mlx->img = mlx_new_image(mlx->ptr, mlx->x, mlx->y);
+	mlx->pix_str = mlx_get_data_addr(mlx->img, &mlx->bpp, &mlx->len, &mlx->endian);
+	mandelbrot(*mlx, 100, 0, 0);
+	mlx_destroy_image(mlx->ptr, img);
+}
+
 int	main(int arg_n, char **arg_s)
 {
 	t_mlx	mlx;
@@ -8,6 +39,8 @@ int	main(int arg_n, char **arg_s)
 	mlx.y = 1080;
 	mlx.ratio = (float)mlx.x / mlx.y;
 	mlx.ptr = mlx_init();
+	mlx.max = 2;
+	mlx.min = -2;
 	if (!mlx.ptr)
 		error("mlx_init fail");
 	mlx.win = mlx_new_window(mlx.ptr, mlx.x, mlx.y, "fractol");
@@ -21,6 +54,7 @@ int	main(int arg_n, char **arg_s)
 		error("mlx_get_data_addr fail");
 	mlx_key_hook(mlx.win, escape, 0);
 	mlx_hook(mlx.win, 17, 0, red_cross, 0);
-	mandelbrot(mlx, 10, 0, 0);
+	mlx_mouse_hook(mlx.win, mouse_check, &mlx);
+	mandelbrot(mlx, 100, 0, 0);
 	mlx_loop(mlx.ptr);
 }

--- a/mandelbrot.c
+++ b/mandelbrot.c
@@ -10,9 +10,9 @@ float	map(int x, int max, float new_min, float new_max)
 
 void	put_color(unsigned char *pixel, unsigned char r, unsigned char g, unsigned char b)
 {
-	pixel[0] = r;
+	pixel[0] = b;
 	pixel[1] = g;
-	pixel[2] = b;
+	pixel[2] = r;
 }
 
 void	reset(t_mlx mlx, t_mandelbrot *man, int x, int y, float a, float b)
@@ -21,8 +21,8 @@ void	reset(t_mlx mlx, t_mandelbrot *man, int x, int y, float a, float b)
 	man->r = 0;
 	man->g = 0;
 	man->blue = 0;
-	man->ca = map(x, mlx.x, -2 * mlx.ratio, 2 * mlx.ratio);
-	man->cb = map(y, mlx.y, -2, 2);
+	man->ca = map(x, mlx.x, mlx.min * mlx.ratio, mlx.max * mlx.ratio);
+	man->cb = map(y, mlx.y, mlx.min, mlx.max);
 	man->a = a;
 	man->b = b;
 }
@@ -49,9 +49,9 @@ void	trans_color(t_mandelbrot *man, int i)
 {
 	if (pow(man->a, 2) + pow(man->b, 2) <= 4)
 	{
-		man->r = 60 * (i) % 255;
-		man->g = 50 * (i) % 255;
-		man->b = 70 * (i) % 255;
+		man->r = (25 * 5 * i) % 255;
+		man->g = (25 * 2 * i) % 255;
+		man->b = (25 * 3 * i) % 255;
 	}
 }
 
@@ -77,4 +77,5 @@ void	mandelbrot(t_mlx mlx, int n, float a, float b)
 		x++;
 	}
 	mlx_put_image_to_window(mlx.ptr, mlx.win, mlx.img, 0, 0);
+	printf("put image\n");
 }


### PR DESCRIPTION
-rgb값을 구현하는 방식을 살짝 바꿨다. 25 * 소수로 해서 다양하게 만들었다.
-mlx 리눅스에서 스크롤 다운이 4번이고 업이 5다.
-절대값 0.04만큼 차이를 줘보고, 지수로 차이를 줘봤는데, 그냥 0.1만큼 차이나게 곱했다.
-새로운 이미지를 만들고 이전 이미지를 제거했다. 기존 이미지 주소에 계속 집어넣으니 중간에 이미지가 안나오더라 이제 연산은 느려도 계속 나온다.
- 확대시에 연산을 많이 하게 되어서 축소보다 확대가 더 느리다. 반복횟수를 줄이면 좀 빨라질 것 같다.
- 속도를 빠르게 하려면 어떻게 해야할까?